### PR TITLE
Signing with secondary userid emails.

### DIFF
--- a/AMPGpg/AMPGpg/AMPGpgEncryption.m
+++ b/AMPGpg/AMPGpg/AMPGpgEncryption.m
@@ -49,10 +49,12 @@ NSString * const AMPGpgEncryptionException = @"AMPGpgEncryption_Exception";
 {
     for(GPGKey *key in [[GPGKeyManager sharedInstance] allKeys])
     {
-        if([key.email isEqualToString:mail])
-        {
-            NSLog(@"AMPGpgEncryption GetKeyForMail GPGKey %@ canAnySign %d canAnyEncrypt %d key.validity %d %@",mail, key.canSign, key.canAnyEncrypt, key.validity, key);
-            return key;
+        for (GPGUserID *uid in key.userIDs) {
+            if([uid.email isEqualToString:mail])
+            {
+                NSLog(@"AMPGpgEncryption GetKeyForMail GPGKey %@ canAnySign %d canAnyEncrypt %d key.validity %d %@",mail, key.canSign, key.canAnyEncrypt, key.validity, key);
+                return key;
+            }
         }
     }
     return nil;


### PR DESCRIPTION
If a key currently has multiple email addresses associated with it, only the primary address can send encrypted or signed emails. This pull request searches each the userid's to try and find any key that matches the email account even if it is not the primary email.
