### PR TITLE
Check all user ID emails, not just primary

### DIFF
--- a/AMPGpg/AMPGpg/AMPGpgEncryption.m
+++ b/AMPGpg/AMPGpg/AMPGpgEncryption.m
@@ -49,10 +49,11 @@ NSString * const AMPGpgEncryptionException = @"AMPGpgEncryption_Exception";
 {
     for(GPGKey *key in [[GPGKeyManager sharedInstance] allKeys])
     {
-        if([key.email isEqualToString:mail])
-        {
-            NSLog(@"AMPGpgEncryption GetKeyForMail GPGKey %@ canAnySign %d canAnyEncrypt %d key.validity %d %@",mail, key.canSign, key.canAnyEncrypt, key.validity, key);
-            return key;
+        for(GPGUserID *userId in key.userIDs) {
+            if([userId.email isEqualToString:mail]) {
+                NSLog(@"AMPGpgEncryption GetKeyForMail GPGKey %@ canAnySign %d canAnyEncrypt %d key.validity %d %@",mail, key.canSign, key.canAnyEncrypt, key.validity, key);
+                return key;
+            }
         }
     }
     return nil;


### PR DESCRIPTION
This would solve the following Tender issue: https://airmail.tenderapp.com/help/discussions/airmail-plug-in-beta/2-gpg-user-ids
